### PR TITLE
allow users with 'write' permissions to use bot

### DIFF
--- a/frrbot.py
+++ b/frrbot.py
@@ -176,7 +176,7 @@ def issue_comment_created(j):
         be "in 1 day" to close the issue in 1 day, or "May 25th" to specify the
         next occurring May 15th.
         """
-        if perm != "admin":
+        if perm != "write" or perm != "admin":
             app.logger.warning("[-] User '{}' ({}) isn't authorized to use this command".format(sender, perm))
             return
 


### PR DESCRIPTION
Users with 'write' can push to repositories. Users with 'read' can
still comment on issues. So its safe to lower privs to 'write' instead
of 'admin'.