### PR TITLE
add bugfix label to PRs

### DIFF
--- a/frrbot.py
+++ b/frrbot.py
@@ -521,6 +521,10 @@ curl -s {gisturl} | git apply
                 lbls = map(lambda x: label_map[x], lbls)
                 labels = labels | set(lbls)
 
+            lines = msg.split("\n")
+            if lines[0].find("fix") != -1 or msg.find("Fixes:") != -1:
+                labels.add("bugfix")
+
         if labels:
             self.pull_request.add_to_labels(*labels)
 


### PR DESCRIPTION
Automatically add the "bugfix" label to a PR, if some of the commits
have either word "fix" in the description or word "Fixes:" in the body.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>