### PR TITLE
fix adding bugfix label

### DIFF
--- a/frrbot.py
+++ b/frrbot.py
@@ -717,7 +717,7 @@ curl {stylegist_url} | git apply -
                     labels = labels | set(lbls)
 
                 lines = msg.split("\n")
-                if lines[0].find("fix") != -1 or msg.find("Fixes:") != -1:
+                if lines[0].find(" fix ") != -1 or msg.find("Fixes:") != -1:
                     labels.add("bugfix")
 
         if labels:


### PR DESCRIPTION
Add the label only when we have a separate word "fix" in the commit
message.

"prefix" shouldn't be the trigger :)

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>