### PR TITLE
frrbot: add ctime to the banned functions list

### DIFF
--- a/frrbot.py
+++ b/frrbot.py
@@ -31,6 +31,7 @@ BANNED_FUNCTIONS = [
     ("strcat", "strlcat"),
     ("strcpy", "strlcpy"),
     ("inet_ntoa", "inet_ntop"),
+    ("ctime", "ctime_r"),
 ]
 
 PR_GREETING_MSG = "Thanks for your contribution to FRR!\n\n"


### PR DESCRIPTION
Add ctime to the banned functions list.